### PR TITLE
Setup Mailchimp API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .ropeproject
 __pycache__
 ve
+*.conf

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ WHEEL_VERSION ?= 0.29.0
 VIRTUALENV ?= virtualenv.py
 SUPPORT_DIR ?= requirements/virtualenv_support/
 SCRIPT_FILE ?= mailchimp_subscriber.py
+CONF_FILE ?= mailchimp-subscriber.conf
+USERS_FILE ?= tests/test-user-list.txt
 TEST_FILES ?= *
 MAX_COMPLEXITY ?= 10
 PY_DIRS ?= *.py tests --exclude virtualenv.py
@@ -25,7 +27,7 @@ flake8: $(PY_SENTINAL)
 	$(FLAKE8) $(PY_DIRS) --max-complexity=$(MAX_COMPLEXITY)
 
 run: $(PY_SENTINAL)
-	$(ENV_PYTHON) $(SCRIPT_FILE)
+	$(ENV_PYTHON) $(SCRIPT_FILE) $(CONF_FILE) $(USERS_FILE)
 
 test: $(PY_SENTINAL)
 	$(VE)/bin/python -m tests.test_mailchimp_subscriber

--- a/mailchimp_subscriber.py
+++ b/mailchimp_subscriber.py
@@ -1,11 +1,13 @@
 import sys
 import configparser
+from mailchimp3 import MailChimp
 
 
 def load_conf(conf_file):
     config = configparser.ConfigParser()
     config.read(conf_file)
     return (config['DEFAULT']['MailchimpListID'],
+            config['DEFAULT']['MailchimpUser'],
             config['DEFAULT']['MailchimpKey'])
 
 
@@ -14,11 +16,13 @@ def load_users(users_file):
         return {l.rstrip() for l in f.readlines()}
 
 
-def process_users(users):
+def process_users(users, list_id, mc_user, mc_key):
+    client = MailChimp(mc_user, mc_key)
+    print(client.lists.members.all(list_id, get_all=True))
     return False
 
 
 if __name__ == "__main__":
-    list_id, mc_key = load_conf(sys.argv[1])
+    list_id, mc_user, mc_key = load_conf(sys.argv[1])
     users = load_users(sys.argv[2])
-    process_users(users)
+    process_users(users, list_id, mc_user, mc_key)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,13 @@
+mailchimp3==2.0.17
+requests==2.18.4
+urllib3==1.22
+chardet==3.0.4
+certifi==2017.7.27.1
+idna==2.6
+PySocks==1.6.7
+pyOpenSSL==17.3.0
+cryptography==2.0.3
+
 flake8==3.4.1
 configparser==3.5.0
 pycodestyle==2.3.1

--- a/tests/test.conf
+++ b/tests/test.conf
@@ -1,3 +1,4 @@
 [DEFAULT]
 MailchimpListID = 1234
+MailchimpUser = ctl
 MailchimpKey = 123xyz

--- a/tests/test_mailchimp_subscriber.py
+++ b/tests/test_mailchimp_subscriber.py
@@ -7,8 +7,9 @@ from mailchimp_subscriber import (
 class TestMailchimpSubscriber(unittest.TestCase):
 
     def test_load_conf(self):
-        list_id, mc_key = load_conf('tests/test.conf')
+        list_id, mc_user, mc_key = load_conf('tests/test.conf')
         self.assertEqual(list_id, '1234')
+        self.assertEqual(mc_user, 'ctl')
         self.assertEqual(mc_key, '123xyz')
 
     def test_load_users(self):


### PR DESCRIPTION
This sets up the Python API for MailChimp. It adds its dependencies to
requirements.txt

It also implements a simple test to print out all subscribers from a
given list. It uses a list ID, user name, and API key stored in a conf
file, which should never be commited.