### PR TITLE
Refactor Client class, write to file, and property based testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 ve
 *.conf
+.hypothesis

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ __pycache__
 ve
 *.conf
 .hypothesis
+.DS_STORE
+Non-subscribed*
+runs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.6"
 script:
   - make flake8

--- a/mailchimp_subscriber.py
+++ b/mailchimp_subscriber.py
@@ -10,7 +10,6 @@ from mailchimp3 import MailChimp
 
 # Configuration Global
 CONFIG = ''
-SEND_MC_EMAIL = False
 
 EMAIL_RE = re.compile(r'(^[a-zA-Z0-9_+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)')
 EMAIL_COL = 0
@@ -90,12 +89,9 @@ def load_conf(conf_file):
     config = configparser.ConfigParser()
     config.read(conf_file)
     send_mc_email = False
-    try:
-        if (config['DEFAULT'].getboolean('SendMCEmail',
-                                         fallback=False)):
-            send_mc_email = True
-    except ValueError:
-        pass
+    if (config['DEFAULT'].getboolean('SendMCEmail',
+                                     fallback=False)):
+        send_mc_email = True
 
     return ({'ListID': config['DEFAULT']['MailchimpListID'],
              'User': config['DEFAULT']['MailchimpUser'],
@@ -129,7 +125,7 @@ def process_users(users, list_id, mc_user, mc_key):
     for client in users.values():
         set_mailchimp_status(client, mc_client, list_id)
 
-    if (SEND_MC_EMAIL):
+    if (CONFIG['SendMCEmail']):
         add_users_to_mailchimp(users.values(), mc_client, list_id)
     else:
         write_users_to_file(users.values())

--- a/mailchimp_subscriber.py
+++ b/mailchimp_subscriber.py
@@ -97,13 +97,13 @@ def process_users(users, list_id, mc_user, mc_key):
     """Takes a list of emails and returns a list of those not subscribed
     to the MailChimp list"""
     mc_client = MailChimp(mc_user, mc_key)
-    for client in users.values:
+    for client in users.values():
         set_mailchimp_status(client, mc_client, list_id)
 
     if (SEND_MC_EMAIL):
-        add_users_to_mailchimp(users.values, mc_client, list_id)
+        add_users_to_mailchimp(users.values(), mc_client, list_id)
     else:
-        write_users_to_file(users.values)
+        write_users_to_file(users.values())
 
 
 def add_users_to_mailchimp(clients, mc_client, list_id):

--- a/mailchimp_subscriber.py
+++ b/mailchimp_subscriber.py
@@ -169,6 +169,7 @@ def write_users_to_file(clients):
                     client.mailchimp_status == 'not_present'):
                 writer.writerow(client.get_all_fields())
 
+
 if __name__ == "__main__":
     CONFIG = load_conf(sys.argv[1])
     users = load_users(sys.argv[2])

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,9 @@ uritemplate==3.0.0
 six==1.11.0
 oauth2client==4.1.2
 httplib2==0.10.3
+hypothesis==3.32.0
+attrs==17.2.0
+coverage==4.4.1
 
 flake8==3.4.1
 configparser==3.5.0

--- a/tests/test.conf
+++ b/tests/test.conf
@@ -2,3 +2,4 @@
 MailchimpListID = 1234
 MailchimpUser = ctl
 MailchimpKey = 123xyz
+SendMCEmail = false

--- a/tests/test_mailchimp_subscriber.py
+++ b/tests/test_mailchimp_subscriber.py
@@ -156,7 +156,8 @@ class TestMailchimpSubscriber(unittest.TestCase):
                    create=True) as mock_file:
             with patch("mailchimp_subscriber.csv.DictWriter.writerow")\
                                 as mock_writerow:
-                # this is a dummy value, we need to use mock_file to pass flake8
+                # this is a dummy value, we need to use mock_file
+                # to pass flake8
                 mock_file.mock_calls
                 # Set the mailchimp status on each client
                 for client in clients:

--- a/tests/test_mailchimp_subscriber.py
+++ b/tests/test_mailchimp_subscriber.py
@@ -1,10 +1,18 @@
 import unittest
 import requests
-from unittest.mock import patch, MagicMock
+from hypothesis import given, strategies as st
+from unittest.mock import patch, MagicMock, mock_open, call
 from mailchimp_subscriber import (
     load_conf, load_users, validate_email,
-    add_user, Client, set_mailchimp_status
+    add_users_to_mailchimp, Client, set_mailchimp_status,
+    write_users_to_file, EMAIL_RE
 )
+
+CLIENT_FACTORY = st.builds(
+                    Client,
+                    st.from_regex(EMAIL_RE),
+                    st.text(min_size=1),
+                    st.text(min_size=1))
 
 
 class TestMailchimpSubscriber(unittest.TestCase):
@@ -16,10 +24,8 @@ class TestMailchimpSubscriber(unittest.TestCase):
         self.assertEqual(validate_email('foo+bar@columbia.edu'), True)
 
     def test_Client(self):
-        self.assertRaises(ValueError, Client, [])
-        self.assertRaises(ValueError, Client, ['foobar', 'John', 'Doe'])
-        self.assertRaises(ValueError, Client, ['foo@bar.com', 'John'])
-        self.assertIsInstance(Client(['foo@bar.com', 'John', 'Doe']),
+        self.assertRaises(ValueError, Client, 'foobar', 'John', 'Doe')
+        self.assertIsInstance(Client('foo@bar.com', 'John', 'Doe'),
                               Client)
 
     @patch('mailchimp_subscriber.MailChimp')
@@ -28,45 +34,46 @@ class TestMailchimpSubscriber(unittest.TestCase):
         mock_client = mock_mail_chimp()
 
         # Test pending
-        ctl_client = Client(['foo@bar.com', 'John', 'Doe'])
+        ctl_client = Client('foo@bar.com', 'John', 'Doe')
         mock_client.lists.members.get = MagicMock(
             return_value={'status': 'pending'})
         set_mailchimp_status(ctl_client, mock_client, '1234')
         self.assertEqual(ctl_client.mailchimp_status, 'pending')
 
         # Test subscribed
-        ctl_client = Client(['foo@bar.com', 'John', 'Doe'])
+        ctl_client = Client('foo@bar.com', 'John', 'Doe')
         mock_client.lists.members.get = MagicMock(
             return_value={'status': 'subscribed'})
         set_mailchimp_status(ctl_client, mock_client, '1234')
         self.assertEqual(ctl_client.mailchimp_status, 'subscribed')
 
         # Test unsubscribed
-        ctl_client = Client(['foo@bar.com', 'John', 'Doe'])
+        ctl_client = Client('foo@bar.com', 'John', 'Doe')
         mock_client.lists.members.get = MagicMock(
             return_value={'status': 'unsubscribed'})
         set_mailchimp_status(ctl_client, mock_client, '1234')
         self.assertEqual(ctl_client.mailchimp_status, 'unsubscribed')
 
         # Test cleaned
-        ctl_client = Client(['foo@bar.com', 'John', 'Doe'])
+        ctl_client = Client('foo@bar.com', 'John', 'Doe')
         mock_client.lists.members.get = MagicMock(
             return_value={'status': 'cleaned'})
         set_mailchimp_status(ctl_client, mock_client, '1234')
         self.assertEqual(ctl_client.mailchimp_status, 'cleaned')
 
         # Test not_present
-        ctl_client = Client(['foo@bar.com', 'John', 'Doe'])
+        ctl_client = Client('foo@bar.com', 'John', 'Doe')
         mock_client.lists.members.get = MagicMock(
             side_effect=requests.exceptions.HTTPError)
         set_mailchimp_status(ctl_client, mock_client, '1234')
         self.assertEqual(ctl_client.mailchimp_status, 'not_present')
 
     def test_load_conf(self):
-        list_id, mc_user, mc_key = load_conf('tests/test.conf')
+        list_id, mc_user, mc_key, send_mc_email = load_conf('tests/test.conf')
         self.assertEqual(list_id, '1234')
         self.assertEqual(mc_user, 'ctl')
         self.assertEqual(mc_key, '123xyz')
+        self.assertEqual(send_mc_email, False)
 
     def test_load_users(self):
         # load_users takes in a csv file and returns Client objects
@@ -99,35 +106,54 @@ class TestMailchimpSubscriber(unittest.TestCase):
     def test_add_users(self, mock_mail_chimp):
         mock_client = mock_mail_chimp()
 
-        client_1 = Client(['foo@bar.com', 'John', 'Doe'])
+        client_1 = Client('foo@bar.com', 'John', 'Doe')
         client_1.mailchimp_status = 'pending'
         mock_client.lists.members.update = MagicMock(
             return_value={'status': 'pending'})
-        self.assertTrue(add_user(client_1, mock_client, '1234'))
+        self.assertTrue(add_users_to_mailchimp(
+                        [client_1], mock_client, '1234'))
 
-        client_2 = Client(['foo@bar.com', 'John', 'Doe'])
+        client_2 = Client('foo@bar.com', 'John', 'Doe')
         client_2.mailchimp_status = 'not_present'
         mock_client.lists.members.update = MagicMock(
             return_value={'status': 'not_present'})
-        self.assertTrue(add_user(client_2, mock_client, '1234'))
+        self.assertTrue(add_users_to_mailchimp(
+                        [client_2], mock_client, '1234'))
 
-        client_3 = Client(['foo@bar.com', 'John', 'Doe'])
+        client_3 = Client('foo@bar.com', 'John', 'Doe')
         client_3.mailchimp_status = 'subscribed'
         mock_client.lists.members.update = MagicMock(
             return_value={'status': 'subscribed'})
-        self.assertFalse(add_user(client_3, mock_client, '1234'))
+        self.assertFalse(add_users_to_mailchimp(
+                         [client_3], mock_client, '1234'))
 
-        client_4 = Client(['foo@bar.com', 'John', 'Doe'])
+        client_4 = Client('foo@bar.com', 'John', 'Doe')
         client_4.mailchimp_status = 'unsubscribed'
         mock_client.lists.members.update = MagicMock(
             return_value={'status': 'unsubscribed'})
-        self.assertFalse(add_user(client_4, mock_client, '1234'))
+        self.assertFalse(add_users_to_mailchimp(
+                         [client_4], mock_client, '1234'))
 
-        client_5 = Client(['foo@bar.com', 'John', 'Doe'])
+        client_5 = Client('foo@bar.com', 'John', 'Doe')
         client_5.mailchimp_status = 'cleaned'
         mock_client.lists.members.update = MagicMock(
             return_value={'status': 'cleaned'})
-        self.assertFalse(add_user(client_5, mock_client, '1234'))
+        self.assertFalse(add_users_to_mailchimp(
+                         [client_5], mock_client, '1234'))
+
+    @given(st.sampled_from(['pending', 'not_present']))
+    @given(st.lists(CLIENT_FACTORY))
+    def test_write_users_to_file(self, status, clients):
+        with patch("mailchimp_subscriber.open", mock_open()) as mock_file:
+            # Set the mailchimp status on each client
+            for client in clients:
+                client.mailchimp_status = status
+            write_users_to_file(clients)
+            for client in clients:
+                assert all(x in mock_file.mock_calls for x in [
+                    call().write(client.email_address + ', '),
+                    call().write(client.first_name + ', '),
+                    call().write(client.last_name + ', ')])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This commit primarily adds the functionality to write out the clients to
a CSV file. This functionality is now the default. If a user wishes to
have Mailchimp send a file, you'll have to set it as a config option.

This commit also refactors the Client class constructor to reduce the
coupling bewteen Client and the file row object. It now takes in the
params one value at a time, rather than reading a whole row. The row
could be malformed, and it doesn't make much sense to have the class
validate this.

Lastly, this commit introduces property based testing for the new write
to file functionality. It uses a combination of Hypothesis to generate
randomized Client objects and mocking to capture calls to the OS.